### PR TITLE
Fix infinite reload caused by malformed app version during unfinished rollout

### DIFF
--- a/api/script/routes/acquisition.ts
+++ b/api/script/routes/acquisition.ts
@@ -83,7 +83,8 @@ function createResponseUsingStorage(
       // 1. To indicate the binary app version when there is an update available
       // 2. To indicate new binary app version when there is no update available 
       // Currently, there's an infinite loop scenario in android when new code push release is roll out under 100%
-      // Android react-native-code-push sdk checks for appVersion to determine if it should check for update by comparing with the package appVersion with binary version
+      //
+      // Android react-native-code-push sdk checks for appVersion to determine if it is proper update by comparing with the package appVersion with binary version
       // If the code-push-server doesn't set the appVersion of the response package for rollout package, the android sdk considers the response as different app version target, and it keeps remove the packages internally, which lead to infinite installing loop.
       // 
       // We are not sure about the impact of original package appVersion, so we patch only rollout package appVersion.

--- a/api/script/routes/acquisition.ts
+++ b/api/script/routes/acquisition.ts
@@ -78,6 +78,15 @@ function createResponseUsingStorage(
       if ((isMissingPatchVersion || isPlainIntegerNumber) && updateObject.originalPackage.appVersion === updateRequest.appVersion) {
         updateObject.originalPackage.appVersion = originalAppVersion;
       }
+
+      // appVersion of the response package has two purpose 
+      // 1. To indicate the binary app version when there is an update available
+      // 2. To indicate the update app version when there is no update available 
+      // Currently, there's an infinite loop scenario in android when new code push release is roll out under 100%
+      // Android react-native-code-push sdk checks for appVersion to determine if it should check for update by comparing with the package appVersion with binary version
+      // If the code-push-server doesn't set the appVersion of the response package for rollout package, the android sdk considers the response as different app version target, and it keeps remove the packages internally, which lead to infinite installing loop.
+      // 
+      // We are not sure about the impact of original package appVersion, so we patch only rollout package appVersion.
       if ((isMissingPatchVersion || isPlainIntegerNumber) && updateObject.rolloutPackage && updateObject.rolloutPackage.appVersion === updateRequest.appVersion) {
         updateObject.rolloutPackage.appVersion = originalAppVersion;
       }

--- a/api/script/routes/acquisition.ts
+++ b/api/script/routes/acquisition.ts
@@ -81,7 +81,7 @@ function createResponseUsingStorage(
 
       // appVersion of the response package has two purpose 
       // 1. To indicate the binary app version when there is an update available
-      // 2. To indicate the update app version when there is no update available 
+      // 2. To indicate new binary app version when there is no update available 
       // Currently, there's an infinite loop scenario in android when new code push release is roll out under 100%
       // Android react-native-code-push sdk checks for appVersion to determine if it should check for update by comparing with the package appVersion with binary version
       // If the code-push-server doesn't set the appVersion of the response package for rollout package, the android sdk considers the response as different app version target, and it keeps remove the packages internally, which lead to infinite installing loop.

--- a/api/script/routes/acquisition.ts
+++ b/api/script/routes/acquisition.ts
@@ -73,12 +73,9 @@ function createResponseUsingStorage(
   if (validationUtils.isValidUpdateCheckRequest(updateRequest)) {
     return storage.getPackageHistoryFromDeploymentKey(updateRequest.deploymentKey).then((packageHistory: storageTypes.Package[]) => {
       const updateObject: UpdateCheckCacheResponse = acquisitionUtils.getUpdatePackageInfo(packageHistory, updateRequest);
-      if ((isMissingPatchVersion || isPlainIntegerNumber) && updateObject.originalPackage.appVersion === updateRequest.appVersion) {
-        // Set the appVersion of the response to the original one with the missing patch version or plain number
-        updateObject.originalPackage.appVersion = originalAppVersion;
-        if (updateObject.rolloutPackage) {
-          updateObject.rolloutPackage.appVersion = originalAppVersion;
-        }
+      updateObject.originalPackage.appVersion = originalAppVersion;
+      if (updateObject.rolloutPackage) {
+        updateObject.rolloutPackage.appVersion = originalAppVersion;
       }
 
       const cacheableResponse: redis.CacheableResponse = {

--- a/api/script/routes/acquisition.ts
+++ b/api/script/routes/acquisition.ts
@@ -85,7 +85,7 @@ function createResponseUsingStorage(
       // Currently, there's an infinite loop scenario in android when new code push release is roll out under 100%
       //
       // Android react-native-code-push sdk checks for appVersion to determine if it is proper update by comparing with the package appVersion with binary version
-      // If the code-push-server doesn't set the appVersion of the response package for rollout package, the android sdk considers the response as different app version target, and it keeps remove the packages internally, which lead to infinite installing loop.
+      // If the code-push-server doesn't set the appVersion of rollout package in the response, the android sdk considers the response as different app version target, and it keeps remove the packages internally, which lead to infinite installing loop in mandatory update scenario.
       // 
       // We are not sure about the impact of original package appVersion, so we patch only rollout package appVersion.
       if ((isMissingPatchVersion || isPlainIntegerNumber) && updateObject.rolloutPackage && updateObject.rolloutPackage.appVersion === updateRequest.appVersion) {

--- a/api/script/routes/acquisition.ts
+++ b/api/script/routes/acquisition.ts
@@ -73,8 +73,12 @@ function createResponseUsingStorage(
   if (validationUtils.isValidUpdateCheckRequest(updateRequest)) {
     return storage.getPackageHistoryFromDeploymentKey(updateRequest.deploymentKey).then((packageHistory: storageTypes.Package[]) => {
       const updateObject: UpdateCheckCacheResponse = acquisitionUtils.getUpdatePackageInfo(packageHistory, updateRequest);
-      updateObject.originalPackage.appVersion = originalAppVersion;
-      if (updateObject.rolloutPackage) {
+      
+      // Set the appVersion of the response to the original one with the missing patch version or plain number
+      if ((isMissingPatchVersion || isPlainIntegerNumber) && updateObject.originalPackage.appVersion === updateRequest.appVersion) {
+        updateObject.originalPackage.appVersion = originalAppVersion;
+      }
+      if ((isMissingPatchVersion || isPlainIntegerNumber) && updateObject.rolloutPackage && updateObject.rolloutPackage.appVersion === updateRequest.appVersion) {
         updateObject.rolloutPackage.appVersion = originalAppVersion;
       }
 


### PR DESCRIPTION
When the following conditions are met:
- A package is marked as mandatory
- The package rollout is unfinished
- The client app version is missing a patch version, e.g. `14.1`
- The package is the first release for the targeted version

The API returns a malformed app version, which causes the client to enter an infinite reload loop.

Expected behavior:
When a mandatory package rollout is unfinished, the API should return the `originalAppVersion` instead of a malformed one, regardless of whether `originalPackage` for the requested version exists.