### PR TITLE
Remove Microsoft/AppCenter references

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,21 +1,23 @@
-    MIT License
+Copyright (c) Microsoft Corporation.
 
-    Copyright (c) Microsoft Corporation.
+Additional modifications copyright (c) Codemagic.
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
+MIT License
 
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Visual Studio App Center CodePush Standalone Version
+# CodePush Server
 
-[CodePush](https://learn.microsoft.com/en-us/appcenter/distribution/codepush/) is an App Center feature that enables React Native developers to deploy mobile app updates directly to their users’ devices. It consists of two parts: CodePush Server where developers can publish app updates to (e.g. JS, HTML, CSS or image changes), and [CodePush React Native Client SDK](https://github.com/Microsoft/react-native-code-push) that enables querying for updates from within an app.
+CodePush Server is an over-the-air update service for React Native applications. Developers can use it to publish app updates such as JavaScript, HTML, CSS, and image changes to a self-hosted server, while mobile apps use the [CodePush React Native Client SDK](https://github.com/codemagic-ci-cd/react-native-code-push) to query and install updates.
 
-We announced that Visual Studio App Center will be retired on March 31, 2025. You can learn more about the support timeline and alternatives on https://aka.ms/appcenter/retire. In order to let developers keep using CodePush functionality after App Center is fully retired, we created a standalone version of CodePush Server that can be deployed and used independently from App Center itself. Code of this standalone version can be found in this repository. It is fully compatible with [CodePush React Native Client SDK](https://github.com/Microsoft/react-native-code-push).
+CodePush was originally created by Microsoft and open-sourced under the MIT License. This server is now maintained by Codemagic at [codemagic-ci-cd/code-push-server](https://github.com/codemagic-ci-cd/code-push-server), alongside the compatible [codemagic-ci-cd/react-native-code-push](https://github.com/codemagic-ci-cd/react-native-code-push) SDK.
 
 
 ## Getting Started
@@ -20,18 +20,9 @@ The CodePush CLI, located in `cli` subdirectory, is a command-line tool that all
 
 ## Contributing
 
-While we cannot accept contributions or issues in this repository; however, as a permissively licensed open-source project, it is ready for community development and forks independently.
+Contributions are welcome. Please use [GitHub Issues](https://github.com/codemagic-ci-cd/code-push-server/issues) to report bugs, request features, or discuss changes before opening larger pull requests.
 
 
 ## Support
 
-This code is provided “as is”, because of that Microsoft will not provide support services for it.
-
-
-## Legal Notice
-
-Microsoft grants you access to the code in this repository under the MIT License, see the [LICENSE](./LICENSE) to learn more.
-
-Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries. The license for this code does not grant you rights to use any Microsoft names, logos, or trademarks. Go to [Microsoft Trademark and Brand Guidelines](http://go.microsoft.com/fwlink/?LinkID=254653) for more information.
-
-Privacy information can be found at https://privacy.microsoft.com/.
+For support, usage questions, and community discussion, please open a [GitHub Issue](https://github.com/codemagic-ci-cd/code-push-server/issues).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,41 +1,44 @@
-<!-- BEGIN MICROSOFT SECURITY.MD V0.0.9 BLOCK -->
+# Security Policy
 
-## Security
+## Reporting a Vulnerability
 
-Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet) and [Xamarin](https://github.com/xamarin).
+Please do not report security vulnerabilities through public GitHub issues.
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/security.md/definition), please report it to us as described below.
+Use GitHub Private Vulnerability Reporting for this repository:
 
-## Reporting Security Issues
+1. Open the repository on GitHub.
+1. Go to the **Security** tab.
+1. Select **Report a vulnerability**.
+1. Include as much detail as possible so maintainers can reproduce and assess the issue.
 
-**Please do not report security vulnerabilities through public GitHub issues.**
+## What to Report
 
-Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/security.md/msrc/create-report).
+Please report vulnerabilities that could affect the confidentiality, integrity, or availability of CodePush Server, the CodePush CLI, or update delivery. Useful reports include:
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
+- Authentication or authorization bypasses
+- Privilege escalation between accounts, apps, deployments, or collaborators
+- Update package tampering, signature bypasses, or unsafe release delivery behavior
+- Exposure of deployment keys, access keys, secrets, tokens, or private update artifacts
+- Injection vulnerabilities, cross-site scripting, server-side request forgery, or unsafe deserialization
+- Storage access issues that expose or allow modification of another user's data
+- Dependency vulnerabilities with a realistic exploit path in this project
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+Please include:
 
-Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+- Affected version, commit, branch, or deployment configuration
+- Steps to reproduce the issue
+- Proof-of-concept code or requests, when safe to share
+- Expected and actual behavior
+- Impact and any known mitigations
 
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
+## Response Expectations
 
-This information will help us triage your report more quickly.
+Maintainers aim to acknowledge new vulnerability reports within 5 business days. After initial triage, maintainers will work with the reporter to confirm impact, identify affected versions, prepare fixes, and coordinate disclosure timing.
 
-If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/security.md/msrc/bounty) page for more details about our active programs.
+Response times may vary based on report complexity and maintainer availability, but maintainers will make a good-faith effort to keep reporters updated while an issue is being investigated.
 
-## Preferred Languages
+## Coordinated Disclosure
 
-We prefer all communications to be in English.
+Please keep vulnerability details private until maintainers have investigated the report and, when needed, prepared a fix or mitigation. After a fix is available, maintainers will coordinate public disclosure through GitHub security advisories, release notes, or other appropriate project channels.
 
-## Policy
-
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/security.md/cvd).
-
-<!-- END MICROSOFT SECURITY.MD BLOCK -->
+Reports should be made in good faith and should avoid privacy violations, data destruction, service disruption, or access to data beyond what is necessary to demonstrate the vulnerability.

--- a/api/README.md
+++ b/api/README.md
@@ -2,7 +2,7 @@
 
 The CodePush Server is a Node.js application that powers the CodePush Service. It allows users to deploy and manage over-the-air updates for their react-native applications in a self-hosted environment.
 
-Please refer to [react-native-code-push](https://github.com/microsoft/react-native-code-push) for instructions on how to onboard your application to CodePush.
+Please refer to [react-native-code-push](https://github.com/codemagic-ci-cd/react-native-code-push) for instructions on how to onboard your application to CodePush.
 
 ## Deployment
 
@@ -103,7 +103,7 @@ More detailed instructions on how to set up one can be found in the section [OAu
 
 ## Configure react-native-code-push
 
-In order for [react-native-code-push](https://github.com/microsoft/react-native-code-push) to use your server, additional configuration value is needed.
+In order for [react-native-code-push](https://github.com/codemagic-ci-cd/react-native-code-push) to use your server, additional configuration value is needed.
 
 ### Android
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -115,7 +115,7 @@ code-push-standalone app add MyApp-iOS
 
 _NOTE: Using the same app for iOS and Android may cause installation exceptions because the CodePush update package produced for iOS will have different content from the update produced for Android._
 
-All new apps automatically come with two deployments (`Staging` and `Production`) so that you can begin distributing updates to multiple channels without needing to do anything extra (see deployment instructions below). After you create an app, the CLI will output the deployment keys for the `Staging` and `Production` deployments, which you can begin using to configure your mobile clients with the [React Native](http://github.com/Microsoft/react-native-code-push) SDK.
+All new apps automatically come with two deployments (`Staging` and `Production`) so that you can begin distributing updates to multiple channels without needing to do anything extra (see deployment instructions below). After you create an app, the CLI will output the deployment keys for the `Staging` and `Production` deployments, which you can begin using to configure your mobile clients with the [React Native](https://github.com/codemagic-ci-cd/react-native-code-push) SDK.
 
 If you decide that you don't like the name you gave to an app, you can rename it at any time using the following command:
 


### PR DESCRIPTION
This PR updates all documentation to reflect the current project identity under the `codemagic-ci-cd` GitHub organization. See #10 for more context.