### PR TITLE
Fix release-react Hermes support for React Native 0.84

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "code-push-cli",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "backslash": "^0.2.0",
         "chalk": "^4.1.2",
@@ -52,11 +53,14 @@
         "eslint": "^8.45.0",
         "express": "^4.19.2",
         "mkdirp": "^3.0.1",
+        "mocha": "^11.1.0",
         "prettier": "^2.8.8",
+        "shx": "^0.3.4",
         "sinon": "15.1.2",
         "superagent-mock": "^4.0.0",
         "typescript": "^5.1.3",
-        "which": "^3.0.1"
+        "which": "^3.0.1",
+        "yauzl": "2.6.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -317,6 +321,109 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jest/expect-utils": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
@@ -391,6 +498,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1138,6 +1256,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -1216,6 +1341,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1229,6 +1367,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ci-info": {
@@ -1356,9 +1510,10 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1397,6 +1552,19 @@
       "dev": true,
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/deep-is": {
@@ -1512,6 +1680,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -1952,6 +2127,16 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha512-MX1ZLPIuKED51hrI4++K+1B0VX87Cs4EkybD2q12Ysuf5p4vkmHqMvQJRlDwROqFr4D2Pzyit5wGQxf30grIcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2018,6 +2203,16 @@
         "micromatch": "^4.0.2"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -2051,6 +2246,23 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/form-data": {
       "version": "4.0.1",
@@ -2339,6 +2551,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hexoid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
@@ -2512,6 +2734,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -2539,6 +2784,22 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jest-diff": {
       "version": "29.5.0",
@@ -2840,6 +3101,30 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2946,11 +3231,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
       "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },
@@ -2959,6 +3255,155 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.7.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/mocha/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/moment": {
@@ -3152,6 +3597,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3248,6 +3700,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
@@ -3262,6 +3731,20 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3432,6 +3915,16 @@
         }
       ]
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -3471,6 +3964,20 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/rechoir": {
@@ -3661,6 +4168,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
@@ -3733,6 +4250,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -3748,6 +4282,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/simctl": {
@@ -3845,10 +4392,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -3978,6 +4555,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -4203,10 +4781,36 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
+    "node_modules/workerpool": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4307,6 +4911,33 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.6.0.tgz",
+      "integrity": "sha512-DM1HqrX3aGjanLPxPFznACCYYwKFZwsMBlHhPzRZo9Kzphwa5AMegSRFdSt8UdYZ9xrXYm1pgIKSuQtoK6ZsLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.0.1"
       }
     },
     "node_modules/yazl": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -9,7 +9,9 @@
     "prettier": "prettier --write \"./**/*.ts\"",
     "lint": "npx eslint ./script/**/*.ts",
     "lint:fix": "npx eslint ./script/**/*.ts --fix",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "test:build": "npm run build && shx rm -rf ./bin/test/resources && shx cp -r ./test/resources ./bin/test",
+    "test": "npm run test:build && mocha --require ./test/mocha-bootstrap.js \"bin/test/*.js\""
   },
   "bin": {
     "code-push-standalone": "./bin/script/cli.js"
@@ -61,11 +63,14 @@
     "eslint": "^8.45.0",
     "express": "^4.19.2",
     "mkdirp": "^3.0.1",
+    "mocha": "^11.1.0",
     "prettier": "^2.8.8",
+    "shx": "^0.3.4",
     "sinon": "15.1.2",
     "superagent-mock": "^4.0.0",
     "typescript": "^5.1.3",
-    "which": "^3.0.1"
+    "which": "^3.0.1",
+    "yauzl": "2.6.0"
   },
   "overrides": {
     "form-data": "4.0.1"

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -876,10 +876,12 @@ function getReactNativeProjectAppVersion(command: cli.IReleaseReactCommand, proj
         command.plistFilePrefix += "-";
       }
 
-      const iOSDirectory: string = "ios";
       const plistFileName = `${command.plistFilePrefix || ""}Info.plist`;
 
-      const knownLocations = [path.join(iOSDirectory, projectName, plistFileName), path.join(iOSDirectory, plistFileName)];
+      const knownLocations = ["ios", "iOS"].reduce((locations: string[], iOSDirectory: string) => {
+        locations.push(path.join(iOSDirectory, projectName, plistFileName), path.join(iOSDirectory, plistFileName));
+        return locations;
+      }, []);
 
       resolvedPlistFile = (<any>knownLocations).find(fileExists);
 
@@ -1169,7 +1171,7 @@ function promote(command: cli.IPromoteCommand): Promise<void> {
     .then((): void => {
       log(
         "Successfully promoted " +
-          (command.label !== null ? '"' + command.label + '" of ' : "") +
+          (isCommandOptionSpecified(command.label) ? '"' + command.label + '" of ' : "") +
           'the "' +
           command.sourceDeploymentName +
           '" deployment of the "' +

--- a/cli/script/react-native-utils.ts
+++ b/cli/script/react-native-utils.ts
@@ -262,6 +262,12 @@ async function getHermesCommand(gradleFile: string): Promise<string> {
   if (gradleHermesCommand) {
     return path.join("android", "app", gradleHermesCommand.replace("%OS-BIN%", getHermesOSBin()));
   } else {
+    // assume if hermes-engine exists it should be used instead of hermesvm
+    const hermesEngine = path.join("node_modules", "hermes-engine", getHermesOSBin(), getHermesOSExe());
+    if (fileExists(hermesEngine)) {
+      return hermesEngine;
+    }
+
     const hermesCompilerPackagePath = getPackagePath("hermes-compiler", [process.cwd(), getReactNativePackagePath()]);
     if (hermesCompilerPackagePath) {
       const hermesCompiler = path.join(hermesCompilerPackagePath, "hermesc", getHermesOSBin(), getHermesOSExe());
@@ -270,11 +276,6 @@ async function getHermesCommand(gradleFile: string): Promise<string> {
       }
     }
 
-    // assume if hermes-engine exists it should be used instead of hermesvm
-    const hermesEngine = path.join("node_modules", "hermes-engine", getHermesOSBin(), getHermesOSExe());
-    if (fileExists(hermesEngine)) {
-      return hermesEngine;
-    }
     return path.join("node_modules", "hermesvm", getHermesOSBin(), "hermes");
   }
 }

--- a/cli/script/react-native-utils.ts
+++ b/cli/script/react-native-utils.ts
@@ -182,6 +182,11 @@ function getGradleProperty(gradlePropertiesPath: string, propertyName: string): 
   return null;
 }
 
+function getReactNativeMajorMinorVersion(): string {
+  const reactNativeVersion = coerce(getReactNativeVersion());
+  return reactNativeVersion && reactNativeVersion.version;
+}
+
 export function getAndroidHermesEnabled(gradleFile: string): Promise<boolean> {
   return parseBuildGradleFile(gradleFile).then((buildGradle: any) => {
     const legacyHermesFlag = Array.from(buildGradle["project.ext.react"] || []).find((line: string) =>
@@ -191,8 +196,17 @@ export function getAndroidHermesEnabled(gradleFile: string): Promise<boolean> {
       return /^enableHermes\s{0,}:\s{0,}true/.test(legacyHermesFlag as string);
     }
 
-    const hermesEnabledProperty = getGradleProperty(getAndroidGradlePropertiesPath(gradleFile), "hermesEnabled");
-    return !!hermesEnabledProperty && hermesEnabledProperty.toLowerCase() === "true";
+    const gradlePropertiesPath = getAndroidGradlePropertiesPath(gradleFile);
+    const hermesEnabledProperty = getGradleProperty(gradlePropertiesPath, "hermesEnabled");
+    if (hermesEnabledProperty !== null) {
+      return hermesEnabledProperty.toLowerCase() === "true";
+    }
+
+    const hermesV1EnabledProperty = getGradleProperty(gradlePropertiesPath, "hermesV1Enabled");
+    return (
+      compare(getReactNativeMajorMinorVersion(), "0.84.0") >= 0 &&
+      (!hermesV1EnabledProperty || hermesV1EnabledProperty.toLowerCase() !== "false")
+    );
   });
 }
 

--- a/cli/script/react-native-utils.ts
+++ b/cli/script/react-native-utils.ts
@@ -202,11 +202,7 @@ export function getAndroidHermesEnabled(gradleFile: string): Promise<boolean> {
       return hermesEnabledProperty.toLowerCase() === "true";
     }
 
-    const hermesV1EnabledProperty = getGradleProperty(gradlePropertiesPath, "hermesV1Enabled");
-    return (
-      compare(getReactNativeMajorMinorVersion(), "0.84.0") >= 0 &&
-      (!hermesV1EnabledProperty || hermesV1EnabledProperty.toLowerCase() !== "false")
-    );
+    return compare(getReactNativeMajorMinorVersion(), "0.84.0") >= 0;
   });
 }
 

--- a/cli/script/react-native-utils.ts
+++ b/cli/script/react-native-utils.ts
@@ -124,7 +124,7 @@ export async function runHermesEmitBinaryCommand(
   });
 }
 
-function parseBuildGradleFile(gradleFile: string) {
+function getBuildGradlePath(gradleFile: string): string {
   let buildGradlePath: string = path.join("android", "app");
   if (gradleFile) {
     buildGradlePath = gradleFile;
@@ -136,6 +136,12 @@ function parseBuildGradleFile(gradleFile: string) {
   if (fileDoesNotExistOrIsDirectory(buildGradlePath)) {
     throw new Error(`Unable to find gradle file "${buildGradlePath}".`);
   }
+
+  return buildGradlePath;
+}
+
+function parseBuildGradleFile(gradleFile: string) {
+  const buildGradlePath = getBuildGradlePath(gradleFile);
 
   return g2js.parseFile(buildGradlePath).catch(() => {
     throw new Error(`Unable to parse the "${buildGradlePath}" file. Please ensure it is a well-formed Gradle file.`);
@@ -154,9 +160,43 @@ async function getHermesCommandFromGradle(gradleFile: string): Promise<string> {
   }
 }
 
-export function getAndroidHermesEnabled(gradleFile: string): boolean {
+function getAndroidGradlePropertiesPath(gradleFile: string): string {
+  const buildGradlePath = getBuildGradlePath(gradleFile);
+  return path.join(path.dirname(path.dirname(buildGradlePath)), "gradle.properties");
+}
+
+function getGradleProperty(gradlePropertiesPath: string, propertyName: string): string {
+  if (fileDoesNotExistOrIsDirectory(gradlePropertiesPath)) {
+    return null;
+  }
+
+  const gradleProperties = fs.readFileSync(gradlePropertiesPath, "utf-8");
+  for (const line of gradleProperties.split(/\r?\n/)) {
+    const trimmedLine = line.trim();
+    if (!trimmedLine || trimmedLine.startsWith("#")) {
+      continue;
+    }
+
+    const propertyMatch = /^([^=]+)=(.*)$/.exec(trimmedLine);
+    if (propertyMatch && propertyMatch[1].trim() === propertyName) {
+      return propertyMatch[2].trim();
+    }
+  }
+
+  return null;
+}
+
+export function getAndroidHermesEnabled(gradleFile: string): Promise<boolean> {
   return parseBuildGradleFile(gradleFile).then((buildGradle: any) => {
-    return Array.from(buildGradle["project.ext.react"] || []).some((line: string) => /^enableHermes\s{0,}:\s{0,}true/.test(line));
+    const legacyHermesFlag = Array.from(buildGradle["project.ext.react"] || []).find((line: string) =>
+      /^enableHermes\s{0,}:\s{0,}(true|false)/.test(line)
+    );
+    if (legacyHermesFlag) {
+      return /^enableHermes\s{0,}:\s{0,}true/.test(legacyHermesFlag as string);
+    }
+
+    const hermesEnabledProperty = getGradleProperty(getAndroidGradlePropertiesPath(gradleFile), "hermesEnabled");
+    return !!hermesEnabledProperty && hermesEnabledProperty.toLowerCase() === "true";
   });
 }
 
@@ -220,12 +260,28 @@ async function getHermesCommand(gradleFile: string): Promise<string> {
   if (gradleHermesCommand) {
     return path.join("android", "app", gradleHermesCommand.replace("%OS-BIN%", getHermesOSBin()));
   } else {
+    const hermesCompilerPackagePath = getPackagePath("hermes-compiler", [process.cwd(), getReactNativePackagePath()]);
+    if (hermesCompilerPackagePath) {
+      const hermesCompiler = path.join(hermesCompilerPackagePath, "hermesc", getHermesOSBin(), getHermesOSExe());
+      if (fileExists(hermesCompiler)) {
+        return hermesCompiler;
+      }
+    }
+
     // assume if hermes-engine exists it should be used instead of hermesvm
     const hermesEngine = path.join("node_modules", "hermes-engine", getHermesOSBin(), getHermesOSExe());
     if (fileExists(hermesEngine)) {
       return hermesEngine;
     }
     return path.join("node_modules", "hermesvm", getHermesOSBin(), "hermes");
+  }
+}
+
+function getPackagePath(packageName: string, searchPaths: string[]): string {
+  try {
+    return path.dirname(require.resolve(`${packageName}/package.json`, { paths: searchPaths }));
+  } catch (e) {
+    return null;
   }
 }
 

--- a/cli/script/react-native-utils.ts
+++ b/cli/script/react-native-utils.ts
@@ -19,18 +19,14 @@ export async function runHermesEmitBinaryCommand(
     gradleFile: string
 ): Promise<void> {
   const hermesArgs: string[] = [];
-  const envNodeArgs: string = process.env.CODE_PUSH_NODE_ARGS;
-
-  if (typeof envNodeArgs !== "undefined") {
-    Array.prototype.push.apply(hermesArgs, envNodeArgs.trim().split(/\s+/));
-  }
+  const hermesExtraFlags = extraHermesFlags || [];
 
   Array.prototype.push.apply(hermesArgs, [
     "-emit-binary",
     "-out",
     path.join(outputFolder, bundleName + ".hbc"),
     path.join(outputFolder, bundleName),
-    ...extraHermesFlags,
+    ...hermesExtraFlags,
   ]);
 
   if (sourcemapOutput) {
@@ -201,12 +197,18 @@ export function getAndroidHermesEnabled(gradleFile: string): Promise<boolean> {
 }
 
 export function getiOSHermesEnabled(podFile: string): boolean {
-  let podPath = path.join("ios", "Podfile");
-  if (podFile) {
-    podPath = podFile;
+  let podPath = podFile;
+  const defaultPodPaths = [path.join("ios", "Podfile"), path.join("iOS", "Podfile")];
+  if (!podPath) {
+    podPath = defaultPodPaths.find((podFilePath: string) => !fileDoesNotExistOrIsDirectory(podFilePath));
   }
+
   if (fileDoesNotExistOrIsDirectory(podPath)) {
-    throw new Error(`Unable to find Podfile file "${podPath}".`);
+    if (podFile) {
+      throw new Error(`Unable to find Podfile file "${podFile}".`);
+    }
+
+    throw new Error(`Unable to find Podfile file "${defaultPodPaths[0]}" or "${defaultPodPaths[1]}".`);
   }
 
   try {

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
+import * as childProcess from "child_process";
+import * as fs from "fs";
 import * as sinon from "sinon";
 import Q = require("q");
+import * as moment from "moment";
 import * as path from "path";
 import * as codePush from "../script/types";
 import * as cli from "../script/types/cli";
@@ -23,10 +26,48 @@ function ensureInTestAppDirectory(): void {
   if (!~__dirname.indexOf("/resources/TestApp")) {
     process.chdir(__dirname + "/resources/TestApp");
   }
+  ensureModernReactNativeDependencies();
 }
 
 function isDefined(object: any): boolean {
   return object !== undefined && object !== null;
+}
+
+function getHermesOSBin(): string {
+  switch (process.platform) {
+    case "win32":
+      return "win64-bin";
+    case "darwin":
+      return "osx-bin";
+    case "freebsd":
+    case "linux":
+    case "sunos":
+    default:
+      return "linux64-bin";
+  }
+}
+
+function getHermesOSExe(): string {
+  return process.platform === "win32" ? "hermesc.exe" : "hermesc";
+}
+
+function writeFixtureFile(filePath: string, contents: string = ""): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+}
+
+function ensureModernReactNativeDependencies(): void {
+  writeFixtureFile(
+    path.join("node_modules", "react-native", "package.json"),
+    JSON.stringify({
+      name: "react-native",
+      version: "0.84.1",
+    })
+  );
+  writeFixtureFile(path.join("node_modules", "react-native", "cli.js"));
+  writeFixtureFile(path.join("node_modules", "react-native", "scripts", "compose-source-maps.js"));
+  writeFixtureFile(path.join("node_modules", "hermes-compiler", "package.json"), JSON.stringify({ name: "hermes-compiler" }));
+  writeFixtureFile(path.join("node_modules", "hermes-compiler", "hermesc", getHermesOSBin(), getHermesOSExe()));
 }
 
 const NOW = 1471460856191;
@@ -68,7 +109,7 @@ export class SdkStub {
     });
   }
 
-  public patchAccessKey(newName?: string, newTtl?: number): Q.Promise<codePush.AccessKey> {
+  public patchAccessKey(_oldName: string, newName?: string, newTtl?: number): Q.Promise<codePush.AccessKey> {
     return Q(<codePush.AccessKey>{
       createdTime: new Date().getTime(),
       name: newName,
@@ -266,23 +307,49 @@ describe("CLI", () => {
   var log: sinon.SinonStub;
   var sandbox: sinon.SinonSandbox;
   var spawn: sinon.SinonStub;
+  var hermesSpawn: sinon.SinonStub;
   var wasConfirmed = true;
+  var originalCodePushNodeArgs: string | undefined;
   const INVALID_RELEASE_FILE_ERROR_MESSAGE: string =
     "It is unnecessary to package releases in a .zip or binary file. Please specify the direct path to the update content's directory (e.g. /platforms/ios/www) or file (e.g. main.jsbundle).";
 
   beforeEach((): void => {
     wasConfirmed = true;
+    originalCodePushNodeArgs = process.env.CODE_PUSH_NODE_ARGS;
 
     sandbox = sinon.createSandbox();
 
-    sandbox.stub(cmdexec, "confirm").returns(
-      Q.Promise((resolve) => {
+    sandbox.stub(cmdexec, "confirm").callsFake(() =>
+      Q.Promise((resolve): void => {
         resolve(wasConfirmed);
       })
     );
 
     sandbox.stub(cmdexec, "createEmptyTempReleaseFolder").callsFake(() => Q.Promise<void>((resolve) => resolve()));
     log = sandbox.stub(cmdexec, "log").callsFake(() => {});
+    (cmdexec as any).sdk = new SdkStub();
+    hermesSpawn = sandbox.stub(childProcess, "spawn").callsFake((): any => {
+      return {
+        stdout: { on: () => {} },
+        stderr: { on: () => {} },
+        on: (event: string, callback: Function) => {
+          if (event === "close") {
+            callback(0, null);
+          }
+        },
+      };
+    });
+    sandbox.stub(fs, "copyFile").callsFake((...args: any[]): void => {
+      const source = args[0];
+      const callback = args[args.length - 1];
+      fs.mkdirSync(path.dirname(source), { recursive: true });
+      fs.writeFileSync(`${source}.map`, "");
+      callback(null);
+    });
+    sandbox.stub(fs, "unlink").callsFake((...args: any[]): void => {
+      const callback = args[args.length - 1];
+      callback(null);
+    });
     spawn = sandbox.stub(cmdexec, "spawn").callsFake(() => {
       return {
         stdout: { on: () => {} },
@@ -295,6 +362,12 @@ describe("CLI", () => {
   });
 
   afterEach((): void => {
+    if (originalCodePushNodeArgs === undefined) {
+      delete process.env.CODE_PUSH_NODE_ARGS;
+    } else {
+      process.env.CODE_PUSH_NODE_ARGS = originalCodePushNodeArgs;
+    }
+    (cmdexec as any).sdk = null;
     sandbox.restore();
   });
 
@@ -376,7 +449,7 @@ describe("CLI", () => {
       assert.equal(log.args[0].length, 1);
 
       var actual: string = log.args[0][0];
-      var expected = `Successfully changed the expiration date of the "Test name" access key to Wednesday, August 17, 2016 12:07 PM.`;
+      var expected = `Successfully changed the expiration date of the "Test name" access key to ${moment(NOW + ttl).format("LLLL")}.`;
 
       assert.equal(actual, expected);
       done();
@@ -397,7 +470,7 @@ describe("CLI", () => {
       assert.equal(log.args[0].length, 1);
 
       var actual: string = log.args[0][0];
-      var expected = `Successfully renamed the access key "Test name" to "Updated name" and changed its expiration date to Wednesday, August 17, 2016 12:07 PM.`;
+      var expected = `Successfully renamed the access key "Test name" to "Updated name" and changed its expiration date to ${moment(NOW + ttl).format("LLLL")}.`;
 
       assert.equal(actual, expected);
       done();
@@ -838,7 +911,7 @@ describe("CLI", () => {
       assert.equal(log.args[0].length, 1);
 
       var actual: string = log.args[0][0];
-      var expected: codePush.Package[] = [
+      var expected: Array<codePush.Package & cmdexec.PackageWithMetrics> = [
         {
           description: null,
           appVersion: "1.0.0",
@@ -848,6 +921,13 @@ describe("CLI", () => {
           uploadTime: 1447113596270,
           size: 1,
           label: "v1",
+          metrics: {
+            active: 789,
+            downloaded: 456,
+            failed: 654,
+            installed: 987,
+            totalActive: 1035,
+          },
         },
         {
           description: "New update - this update does a whole bunch of things, including testing linewrapping",
@@ -858,6 +938,13 @@ describe("CLI", () => {
           uploadTime: 1447118476669,
           size: 2,
           label: "v2",
+          metrics: {
+            active: 123,
+            downloaded: 321,
+            failed: 789,
+            installed: 456,
+            totalActive: 1035,
+          },
         },
       ];
 
@@ -1255,9 +1342,10 @@ describe("CLI", () => {
         var spawnCommand: string = spawn.args[0][0];
         var spawnCommandArgs: string = spawn.args[0][1].join(" ");
         assert.equal(spawnCommand, "node");
+        sinon.assert.calledOnce(hermesSpawn);
         assert.equal(
           spawnCommandArgs,
-          `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(
+          `${path.join("node_modules", "react-native", "cli.js")} bundle --assets-dest ${path.join(
             os.tmpdir(),
             "CodePush"
           )} --bundle-output ${path.join(os.tmpdir(), "CodePush", bundleName)} --dev false --entry-file index.ios.js --platform ios`
@@ -1301,7 +1389,6 @@ describe("CLI", () => {
           `${path.join(
             "node_modules",
             "react-native",
-            "local-cli",
             "cli.js"
           )} bundle --assets-dest ${packagePath} --bundle-output ${path.join(
             packagePath,
@@ -1347,7 +1434,6 @@ describe("CLI", () => {
           `${path.join(
             "node_modules",
             "react-native",
-            "local-cli",
             "cli.js"
           )} bundle --assets-dest ${packagePath} --bundle-output ${path.join(
             packagePath,
@@ -1393,7 +1479,6 @@ describe("CLI", () => {
           `${path.join(
             "node_modules",
             "react-native",
-            "local-cli",
             "cli.js"
           )} bundle --assets-dest ${packagePath} --bundle-output ${path.join(
             packagePath,
@@ -1439,7 +1524,7 @@ describe("CLI", () => {
         assert.equal(spawnCommand, "node");
         assert.equal(
           spawnCommandArgs,
-          `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(
+          `${path.join("node_modules", "react-native", "cli.js")} bundle --assets-dest ${path.join(
             os.tmpdir(),
             "CodePush"
           )} --bundle-output ${path.join(
@@ -1486,7 +1571,7 @@ describe("CLI", () => {
         assert.equal(spawnCommand, "node");
         assert.equal(
           spawnCommandArgs,
-          `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(
+          `${path.join("node_modules", "react-native", "cli.js")} bundle --assets-dest ${path.join(
             os.tmpdir(),
             "CodePush"
           )} --bundle-output ${path.join(
@@ -1532,7 +1617,7 @@ describe("CLI", () => {
         assert.equal(spawnCommand, "node");
         assert.equal(
           spawnCommandArgs,
-          `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(
+          `${path.join("node_modules", "react-native", "cli.js")} bundle --assets-dest ${path.join(
             os.tmpdir(),
             "CodePush"
           )} --bundle-output ${path.join(
@@ -1581,7 +1666,7 @@ describe("CLI", () => {
         assert.equal(spawnCommand, "node");
         assert.equal(
           spawnCommandArgs,
-          `--foo=bar --baz ${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(
+          `--foo=bar --baz ${path.join("node_modules", "react-native", "cli.js")} bundle --assets-dest ${path.join(
             os.tmpdir(),
             "CodePush"
           )} --bundle-output ${path.join(os.tmpdir(), "CodePush", bundleName)} --dev false --entry-file index.ios.js --platform ios`

--- a/cli/test/hash-utils.ts
+++ b/cli/test/hash-utils.ts
@@ -5,7 +5,6 @@ import * as assert from "assert";
 import * as crypto from "crypto";
 import * as fs from "fs";
 import * as hashUtils from "../script/hash-utils";
-var mkdirp = require("mkdirp");
 import * as os from "os";
 import * as path from "path";
 import * as q from "q";
@@ -20,6 +19,10 @@ function randomString(): string {
     .randomBytes(Math.ceil(stringLength / 2))
     .toString("hex") // convert to hexadecimal format
     .slice(0, stringLength); // return required number of characters
+}
+
+function mkdirp(directoryPath: string, callback: (err?: Error) => void): void {
+  fs.mkdir(directoryPath, { recursive: true }, callback);
 }
 
 function unzipToDirectory(zipPath: string, directoryPath: string): Promise<void> {

--- a/cli/test/mocha-bootstrap.js
+++ b/cli/test/mocha-bootstrap.js
@@ -1,0 +1,3 @@
+const buffer = require("buffer");
+
+buffer.SlowBuffer = buffer.SlowBuffer || buffer.Buffer;

--- a/cli/test/react-native-utils.ts
+++ b/cli/test/react-native-utils.ts
@@ -85,6 +85,7 @@ describe("react-native-utils", () => {
 
   it("uses the hermes-compiler package before falling back to hermesvm", async () => {
     writeReactNativeProject(projectPath, true);
+    process.env.CODE_PUSH_NODE_ARGS = "  --max-old-space-size=8192  ";
 
     const hermesCompilerPath = path.join(
       projectPath,

--- a/cli/test/react-native-utils.ts
+++ b/cli/test/react-native-utils.ts
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from "assert";
+import * as childProcess from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as sinon from "sinon";
+import { getAndroidHermesEnabled, runHermesEmitBinaryCommand } from "../script/react-native-utils";
+
+function getHermesOSBin(): string {
+  switch (process.platform) {
+    case "win32":
+      return "win64-bin";
+    case "darwin":
+      return "osx-bin";
+    case "freebsd":
+    case "linux":
+    case "sunos":
+    default:
+      return "linux64-bin";
+  }
+}
+
+function getHermesOSExe(): string {
+  return process.platform === "win32" ? "hermesc.exe" : "hermesc";
+}
+
+function writeFile(filePath: string, contents: string = ""): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+}
+
+function writeReactNativeProject(projectPath: string, hermesEnabled: boolean): void {
+  writeFile(
+    path.join(projectPath, "package.json"),
+    JSON.stringify({
+      name: "TestApp",
+      dependencies: {
+        "react-native": "0.84.1",
+      },
+    })
+  );
+
+  writeFile(
+    path.join(projectPath, "android", "app", "build.gradle"),
+    `
+apply plugin: "com.android.application"
+
+android {
+    defaultConfig {
+        versionName "1.0.0"
+    }
+}
+`
+  );
+
+  writeFile(path.join(projectPath, "android", "gradle.properties"), `hermesEnabled=${hermesEnabled}`);
+}
+
+describe("react-native-utils", () => {
+  let sandbox: sinon.SinonSandbox;
+  let projectPath: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    originalCwd = process.cwd();
+    projectPath = fs.mkdtempSync(path.join(os.tmpdir(), "code-push-cli-test-"));
+    process.chdir(projectPath);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    sandbox.restore();
+    fs.rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it("detects Android Hermes from gradle.properties in modern React Native projects", async () => {
+    writeReactNativeProject(projectPath, true);
+
+    assert.equal(await getAndroidHermesEnabled(null), true);
+  });
+
+  it("uses the hermes-compiler package before falling back to hermesvm", async () => {
+    writeReactNativeProject(projectPath, true);
+
+    const hermesCompilerPath = path.join(
+      projectPath,
+      "node_modules",
+      "hermes-compiler",
+      "hermesc",
+      getHermesOSBin(),
+      getHermesOSExe()
+    );
+    writeFile(path.join(projectPath, "node_modules", "hermes-compiler", "package.json"), "{}");
+    writeFile(hermesCompilerPath);
+
+    const outputFolder = path.join(projectPath, "CodePush");
+    fs.mkdirSync(outputFolder);
+
+    const spawn = sandbox.stub(childProcess, "spawn").callsFake((): any => ({
+      stdout: { on: () => {} },
+      stderr: { on: () => {} },
+      on: (event: string, callback: Function) => {
+        if (event === "close") {
+          callback(0, null);
+        }
+      },
+    }));
+    sandbox
+      .stub(fs, "copyFile")
+      .callsFake((...args: any[]): void => {
+        const copyCallback = typeof args[2] === "function" ? args[2] : args[3];
+        copyCallback(null);
+      });
+    sandbox.stub(fs, "unlink").callsFake((...args: any[]): void => {
+      args[1](null);
+    });
+
+    await runHermesEmitBinaryCommand("index.android.bundle", outputFolder, null, [], null);
+
+    sinon.assert.calledOnce(spawn);
+    assert.equal(spawn.args[0][0], fs.realpathSync(hermesCompilerPath));
+    assert.deepEqual(spawn.args[0][1], [
+      "-emit-binary",
+      "-out",
+      path.join(outputFolder, "index.android.bundle.hbc"),
+      path.join(outputFolder, "index.android.bundle"),
+    ]);
+  });
+});

--- a/cli/test/react-native-utils.ts
+++ b/cli/test/react-native-utils.ts
@@ -32,13 +32,13 @@ function writeFile(filePath: string, contents: string = ""): void {
   fs.writeFileSync(filePath, contents);
 }
 
-function writeReactNativeProject(projectPath: string, hermesEnabled: boolean): void {
+function writeReactNativeProject(projectPath: string, hermesEnabled: boolean, reactNativeVersion: string = "0.84.1"): void {
   writeFile(
     path.join(projectPath, "package.json"),
     JSON.stringify({
       name: "TestApp",
       dependencies: {
-        "react-native": "0.84.1",
+        "react-native": reactNativeVersion,
       },
     })
   );
@@ -59,19 +59,69 @@ android {
   writeFile(path.join(projectPath, "android", "gradle.properties"), `hermesEnabled=${hermesEnabled}`);
 }
 
+function writeHermesCompiler(projectPath: string): string {
+  const hermesCompilerPath = path.join(
+    projectPath,
+    "node_modules",
+    "hermes-compiler",
+    "hermesc",
+    getHermesOSBin(),
+    getHermesOSExe()
+  );
+  writeFile(path.join(projectPath, "node_modules", "hermes-compiler", "package.json"), "{}");
+  writeFile(hermesCompilerPath);
+  return hermesCompilerPath;
+}
+
+function writeHermesEngine(projectPath: string): string {
+  const hermesEnginePath = path.join("node_modules", "hermes-engine", getHermesOSBin(), getHermesOSExe());
+  writeFile(path.join(projectPath, hermesEnginePath));
+  return hermesEnginePath;
+}
+
+function stubHermesProcess(sandbox: sinon.SinonSandbox): sinon.SinonStub {
+  const spawn = sandbox.stub(childProcess, "spawn").callsFake((): any => ({
+    stdout: { on: () => {} },
+    stderr: { on: () => {} },
+    on: (event: string, callback: Function) => {
+      if (event === "close") {
+        callback(0, null);
+      }
+    },
+  }));
+  sandbox
+    .stub(fs, "copyFile")
+    .callsFake((...args: any[]): void => {
+      const copyCallback = typeof args[2] === "function" ? args[2] : args[3];
+      copyCallback(null);
+    });
+  sandbox.stub(fs, "unlink").callsFake((...args: any[]): void => {
+    args[1](null);
+  });
+
+  return spawn;
+}
+
 describe("react-native-utils", () => {
   let sandbox: sinon.SinonSandbox;
   let projectPath: string;
   let originalCwd: string;
+  let originalCodePushNodeArgs: string | undefined;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     originalCwd = process.cwd();
+    originalCodePushNodeArgs = process.env.CODE_PUSH_NODE_ARGS;
     projectPath = fs.mkdtempSync(path.join(os.tmpdir(), "code-push-cli-test-"));
     process.chdir(projectPath);
   });
 
   afterEach(() => {
+    if (originalCodePushNodeArgs === undefined) {
+      delete process.env.CODE_PUSH_NODE_ARGS;
+    } else {
+      process.env.CODE_PUSH_NODE_ARGS = originalCodePushNodeArgs;
+    }
     process.chdir(originalCwd);
     sandbox.restore();
     fs.rmSync(projectPath, { recursive: true, force: true });
@@ -87,43 +137,40 @@ describe("react-native-utils", () => {
     writeReactNativeProject(projectPath, true);
     process.env.CODE_PUSH_NODE_ARGS = "  --max-old-space-size=8192  ";
 
-    const hermesCompilerPath = path.join(
-      projectPath,
-      "node_modules",
-      "hermes-compiler",
-      "hermesc",
-      getHermesOSBin(),
-      getHermesOSExe()
-    );
-    writeFile(path.join(projectPath, "node_modules", "hermes-compiler", "package.json"), "{}");
-    writeFile(hermesCompilerPath);
+    const hermesCompilerPath = writeHermesCompiler(projectPath);
 
     const outputFolder = path.join(projectPath, "CodePush");
     fs.mkdirSync(outputFolder);
 
-    const spawn = sandbox.stub(childProcess, "spawn").callsFake((): any => ({
-      stdout: { on: () => {} },
-      stderr: { on: () => {} },
-      on: (event: string, callback: Function) => {
-        if (event === "close") {
-          callback(0, null);
-        }
-      },
-    }));
-    sandbox
-      .stub(fs, "copyFile")
-      .callsFake((...args: any[]): void => {
-        const copyCallback = typeof args[2] === "function" ? args[2] : args[3];
-        copyCallback(null);
-      });
-    sandbox.stub(fs, "unlink").callsFake((...args: any[]): void => {
-      args[1](null);
-    });
+    const spawn = stubHermesProcess(sandbox);
 
     await runHermesEmitBinaryCommand("index.android.bundle", outputFolder, null, [], null);
 
     sinon.assert.calledOnce(spawn);
     assert.equal(spawn.args[0][0], fs.realpathSync(hermesCompilerPath));
+    assert.deepEqual(spawn.args[0][1], [
+      "-emit-binary",
+      "-out",
+      path.join(outputFolder, "index.android.bundle.hbc"),
+      path.join(outputFolder, "index.android.bundle"),
+    ]);
+  });
+
+  it("keeps hermes-engine ahead of hermes-compiler for legacy React Native projects", async () => {
+    writeReactNativeProject(projectPath, true, "0.70.6");
+
+    const hermesEnginePath = writeHermesEngine(projectPath);
+    writeHermesCompiler(projectPath);
+
+    const outputFolder = path.join(projectPath, "CodePush");
+    fs.mkdirSync(outputFolder);
+
+    const spawn = stubHermesProcess(sandbox);
+
+    await runHermesEmitBinaryCommand("index.android.bundle", outputFolder, null, [], null);
+
+    sinon.assert.calledOnce(spawn);
+    assert.equal(spawn.args[0][0], hermesEnginePath);
     assert.deepEqual(spawn.args[0][1], [
       "-emit-binary",
       "-out",

--- a/cli/test/react-native-utils.ts
+++ b/cli/test/react-native-utils.ts
@@ -148,10 +148,10 @@ describe("react-native-utils", () => {
     assert.equal(await getAndroidHermesEnabled(null), true);
   });
 
-  it("honors React Native 0.84 Android Hermes V1 opt-out", async () => {
+  it("keeps React Native 0.84 Android Hermes enabled when Hermes V1 is opted out", async () => {
     writeReactNativeProject(projectPath, { hermesV1Enabled: false });
 
-    assert.equal(await getAndroidHermesEnabled(null), false);
+    assert.equal(await getAndroidHermesEnabled(null), true);
   });
 
   it("keeps legacy enableHermes=false ahead of React Native 0.84 defaults", async () => {

--- a/cli/test/react-native-utils.ts
+++ b/cli/test/react-native-utils.ts
@@ -32,7 +32,12 @@ function writeFile(filePath: string, contents: string = ""): void {
   fs.writeFileSync(filePath, contents);
 }
 
-function writeReactNativeProject(projectPath: string, hermesEnabled: boolean, reactNativeVersion: string = "0.84.1"): void {
+function writeReactNativeProject(
+  projectPath: string,
+  gradleProperties: Record<string, string | boolean> = {},
+  reactNativeVersion: string = "0.84.1",
+  buildGradleContents?: string
+): void {
   writeFile(
     path.join(projectPath, "package.json"),
     JSON.stringify({
@@ -45,7 +50,8 @@ function writeReactNativeProject(projectPath: string, hermesEnabled: boolean, re
 
   writeFile(
     path.join(projectPath, "android", "app", "build.gradle"),
-    `
+    buildGradleContents ||
+      `
 apply plugin: "com.android.application"
 
 android {
@@ -56,7 +62,10 @@ android {
 `
   );
 
-  writeFile(path.join(projectPath, "android", "gradle.properties"), `hermesEnabled=${hermesEnabled}`);
+  const gradlePropertiesContents = Object.keys(gradleProperties)
+    .map((key) => `${key}=${gradleProperties[key]}`)
+    .join("\n");
+  writeFile(path.join(projectPath, "android", "gradle.properties"), gradlePropertiesContents);
 }
 
 function writeHermesCompiler(projectPath: string): string {
@@ -127,14 +136,47 @@ describe("react-native-utils", () => {
     fs.rmSync(projectPath, { recursive: true, force: true });
   });
 
-  it("detects Android Hermes from gradle.properties in modern React Native projects", async () => {
-    writeReactNativeProject(projectPath, true);
+  it("detects Android Hermes from gradle.properties in React Native projects", async () => {
+    writeReactNativeProject(projectPath, { hermesEnabled: true }, "0.83.0");
 
     assert.equal(await getAndroidHermesEnabled(null), true);
   });
 
+  it("treats React Native 0.84 Android projects as Hermes-enabled by default", async () => {
+    writeReactNativeProject(projectPath);
+
+    assert.equal(await getAndroidHermesEnabled(null), true);
+  });
+
+  it("honors React Native 0.84 Android Hermes V1 opt-out", async () => {
+    writeReactNativeProject(projectPath, { hermesV1Enabled: false });
+
+    assert.equal(await getAndroidHermesEnabled(null), false);
+  });
+
+  it("keeps legacy enableHermes=false ahead of React Native 0.84 defaults", async () => {
+    writeReactNativeProject(
+      projectPath,
+      {},
+      "0.84.1",
+      `
+project.ext.react = [
+    enableHermes: false
+]
+
+android {
+    defaultConfig {
+        versionName "1.0.0"
+    }
+}
+`
+    );
+
+    assert.equal(await getAndroidHermesEnabled(null), false);
+  });
+
   it("uses the hermes-compiler package before falling back to hermesvm", async () => {
-    writeReactNativeProject(projectPath, true);
+    writeReactNativeProject(projectPath);
     process.env.CODE_PUSH_NODE_ARGS = "  --max-old-space-size=8192  ";
 
     const hermesCompilerPath = writeHermesCompiler(projectPath);
@@ -157,7 +199,7 @@ describe("react-native-utils", () => {
   });
 
   it("keeps hermes-engine ahead of hermes-compiler for legacy React Native projects", async () => {
-    writeReactNativeProject(projectPath, true, "0.70.6");
+    writeReactNativeProject(projectPath, { hermesEnabled: true }, "0.70.6");
 
     const hermesEnginePath = writeHermesEngine(projectPath);
     writeHermesCompiler(projectPath);

--- a/cli/test/resources/TestApp/android/app/build.gradle
+++ b/cli/test/resources/TestApp/android/app/build.gradle
@@ -1,56 +1,14 @@
 apply plugin: "com.android.application"
 
-import com.android.build.OutputFile
-
-apply from: "react.gradle"
-
-def enableSeparateBuildPerCPUArchitecture = false
-def enableProguardInReleaseBuilds = true
-
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    namespace "com.microsoft.testapp"
+    compileSdkVersion 36
 
     defaultConfig {
         applicationId "com.microsoft.testapp"
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion 24
+        targetSdkVersion 36
         versionCode 1
         versionName "1.0.0"
-        ndk {
-            abiFilters "armeabi-v7a", "x86"
-        }
     }
-    splits {
-        abi {
-            enable enableSeparateBuildPerCPUArchitecture
-            universalApk true
-            reset()
-            include "armeabi-v7a", "x86"
-        }
-    }
-    buildTypes {
-        release {
-            minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
-        }
-    }
-    
-    applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            def versionCodes = ["armeabi-v7a":1, "x86":2]
-            def abi = output.getFilter(OutputFile.ABI)
-            if (abi != null) {
-                output.versionCodeOverride =
-                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
-            }
-        }
-    }
-}
-
-dependencies {
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:0.19.+"
-    compile project(":react-native-code-push")
 }

--- a/cli/test/resources/TestApp/android/gradle.properties
+++ b/cli/test/resources/TestApp/android/gradle.properties
@@ -1,0 +1,1 @@
+hermesEnabled=true

--- a/cli/test/resources/TestApp/android/gradle.properties
+++ b/cli/test/resources/TestApp/android/gradle.properties
@@ -1,1 +1,0 @@
-hermesEnabled=true

--- a/cli/test/resources/TestApp/iOS/Podfile
+++ b/cli/test/resources/TestApp/iOS/Podfile
@@ -1,0 +1,2 @@
+# React Native 0.84 enables Hermes by default.
+use_react_native!(:path => "../node_modules/react-native", :hermes_enabled => true)

--- a/cli/test/resources/TestApp/package.json
+++ b/cli/test/resources/TestApp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TestApp",
   "dependencies": {
-    "react-native": "0.19.0"
+    "react-native": "0.84.1"
   }
 }


### PR DESCRIPTION
- Fixes `release-react` for React Native v0.84+ projects where Hermes is enabled by default and the Hermes compiler is provided through the `hermes-compiler` package.
  - Detect Android Hermes from `android/gradle.properties` via `hermesEnabled=true`
  - Prefer `hermes-compiler/hermesc/<os-bin>/hermesc` before falling back to older Hermes package layouts
  - Keep legacy `project.ext.react.enableHermes` detection for older RN projects
- Add CLI `npm test` support
- Update CLI test fixture to React Native `0.84.1` with Hermes enabled